### PR TITLE
fix: use KV1Secrets type for kv1_secrets (via dinko_mitic@comcast.com)

### DIFF
--- a/reader/reader.go
+++ b/reader/reader.go
@@ -209,17 +209,17 @@ func (s KV1Secrets) GetOutput(ctx context.Context, r *Reader) (OutputList, error
 }
 
 type DC struct {
-	Vars       EnvVars   `yaml:"vars,omitempty"`
-	Secrets    Secrets   `yaml:"secrets,omitempty"`
-	KVSecrets  KVSecrets `yaml:"kv_secrets,omitempty"`
-	KV1Secrets KVSecrets `yaml:"kv1_secrets,omitempty"`
+	Vars       EnvVars    `yaml:"vars,omitempty"`
+	Secrets    Secrets    `yaml:"secrets,omitempty"`
+	KVSecrets  KVSecrets  `yaml:"kv_secrets,omitempty"`
+	KV1Secrets KV1Secrets `yaml:"kv1_secrets,omitempty"`
 }
 
 type Environment struct {
 	Vars       EnvVars       `yaml:"vars,omitempty"`
 	Secrets    Secrets       `yaml:"secrets,omitempty"`
 	KVSecrets  KVSecrets     `yaml:"kv_secrets,omitempty"`
-	KV1Secrets KVSecrets     `yaml:"kv1_secrets,omitempty"`
+	KV1Secrets KV1Secrets    `yaml:"kv1_secrets,omitempty"`
 	Dcs        map[string]DC `yaml:"dcs,omitempty"`
 }
 
@@ -227,7 +227,7 @@ type Variables struct {
 	Vars         EnvVars                `yaml:"vars,omitempty"`
 	Secrets      Secrets                `yaml:"secrets,omitempty"`
 	KVSecrets    KVSecrets              `yaml:"kv_secrets,omitempty"`
-	KV1Secrets   KVSecrets              `yaml:"kv1_secrets,omitempty"`
+	KV1Secrets   KV1Secrets             `yaml:"kv1_secrets,omitempty"`
 	Environments map[string]Environment `yaml:"environments,omitempty"`
 }
 

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -596,7 +596,7 @@ func TestSkipVault_Reader(t *testing.T) {
 						Path: "path/test",
 						Vars: KVSecret{"KVSecret1": "kvsecret1"},
 					}},
-					KV1Secrets: KVSecrets{{
+					KV1Secrets: KV1Secrets{{
 						Path: "path2/test",
 						Vars: KVSecret{
 							"KV1Secret1": "another one",


### PR DESCRIPTION
Per Dinko:
Fixed a type declaration bug where kv1_secrets fields in the DC, Environment, and Variables structs were incorrectly typed as KVSecrets instead of KV1Secrets. This caused kv1_secrets configurations to be processed by the KV v2 handler, which attempted to read secrets using the KV v2 API path format (secret/data/...) instead of the correct KV v1 format (secret/...), resulting in 403 permission errors even when users had valid access to the KV v1 paths.

The fix ensures kv1_secrets are always processed as KV v1 secrets, matching the behavior of direct vault CLI commands.